### PR TITLE
Target WP 8.1 also

### DIFF
--- a/Crypto/crypto.csproj
+++ b/Crypto/crypto.csproj
@@ -15,7 +15,7 @@
     <RootNamespace>Org.BouncyCastle</RootNamespace>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ValidateXaml>true</ValidateXaml>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 BouncyCastle-PCL
 ================
 
-PCL Version of BouncyCastle targetting .NET, SL, WP and WinRT
+PCL Version of BouncyCastle targetting .NET Framework 4, Silverlight 5, and WinRT


### PR DESCRIPTION
Hello, it seems we meet again as I'd like to use another of your libraries for my WP8.1 project :) 

I added targeting to WP 8.1 (WinRT framework) also by checking the box that would ask if I'd like to do so. Tested locally - seems to be fine. 

I didn't touch any of the other targets because I'm not using them, but it looks like you're targeting an old version of .NET, too. I'm not sure what you use this for, but I figured I'd point it out.

Thanks!
-Michelle
